### PR TITLE
Allow passing in window.open options as prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ The component accepts the following props:
 |**`onAfterPrint`**|function|A callback function that triggers after print
 |**`closeAfterPrint`**|boolean|Close the print window after action
 |**`bodyClass`**|string|Optional class to pass to the print window body
-|**`printWindowOptions`**|object|Options to pass to the third argument of window.open(). Removes and overrides default properties. 
+|**`printWindowOptions`**|object|Options to pass to the third argument of `window.open()`. Removes and overrides default properties. 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ The component accepts the following props:
 |**`onAfterPrint`**|function|A callback function that triggers after print
 |**`closeAfterPrint`**|boolean|Close the print window after action
 |**`bodyClass`**|string|Optional class to pass to the print window body
+|**`printWindowOptions`**|object|Options to pass to the third argument of window.open(). Removes and overrides default properties. 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ class ReactToPrint extends React.Component {
     closeAfterPrint: PropTypes.bool,
     /** Optional class to pass to the print window body */
     bodyClass: PropTypes.string,
+    /** Options to pass to the third argument of window.open() */
+    printWindowOptions: PropTypes.shape({}),
     /** Debug Mode */
     debug: PropTypes.bool
   };
@@ -27,6 +29,11 @@ class ReactToPrint extends React.Component {
     copyStyles: true,
     closeAfterPrint: true,
     bodyClass: '',
+    printWindowOptions: {
+      status: 'no',
+      toolbar: 'no',
+      scrollbars: 'yes',
+    },
     debug: false
   };
 
@@ -51,8 +58,10 @@ class ReactToPrint extends React.Component {
       copyStyles,
       onAfterPrint
     } = this.props;
+    
+    const mappedPrintWindowOptions = Object.keys(printWindowOptions).map(m => `${m}=${printWindowOptions[m]}`).join(', ');
 
-    let printWindow = window.open("", "Print", "status=no, toolbar=no, scrollbars=yes", "false");
+    let printWindow = window.open('', 'Print', mappedPrintWindowOptions, 'false');
     
     if (onAfterPrint) {
       printWindow.onbeforeunload = onAfterPrint;

--- a/src/index.js
+++ b/src/index.js
@@ -165,10 +165,6 @@ class ReactToPrint extends React.Component {
     if (this.props.bodyClass.length) {
       printWindow.document.body.classList.add(this.props.bodyClass);
     }
-    
-    if (this.props.bodyClass.length) {
-      printWindow.document.body.classList.add(this.props.bodyClass);
-    }
 
     /* remove date/time from top */
     let styleEl = printWindow.document.createElement('style');

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,8 @@ class ReactToPrint extends React.Component {
     const {
       content,
       copyStyles,
-      onAfterPrint
+      onAfterPrint,
+      printWindowOptions
     } = this.props;
     
     const mappedPrintWindowOptions = Object.keys(printWindowOptions).map(m => `${m}=${printWindowOptions[m]}`).join(', ');


### PR DESCRIPTION
Adds a `printWindowOptions` prop that allows passing an object which will get mapped to a string and passed to the third argument of `window.open()`.

https://developer.mozilla.org/en-US/docs/Web/API/Window/open